### PR TITLE
docblocks and null values

### DIFF
--- a/Symfony2/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Symfony2/Sniffs/Commenting/FunctionCommentSniff.php
@@ -65,16 +65,6 @@ class Symfony2_Sniffs_Commenting_FunctionCommentSniff
         $tokens = $phpcsFile->getTokens();
         $code = $tokens[$commentEnd]['code'];
 
-        // a comment is not required on protected/private methods
-        $method = $phpcsFile->getMethodProperties($stackPtr);
-        $commentRequired = 'public' == $method['scope'];
-
-        if (($code === T_COMMENT && !$commentRequired)
-            || ($code !== T_DOC_COMMENT && !$commentRequired)
-        ) {
-            return;
-        }
-
         parent::process($phpcsFile, $stackPtr);
     }
 
@@ -189,6 +179,6 @@ class Symfony2_Sniffs_Commenting_FunctionCommentSniff
             $returnPos++;
         } while ($tokens[$returnPos]['code'] === T_WHITESPACE);
 
-        return $tokens[$returnPos]['code'] !== T_SEMICOLON;
+        return ($tokens[$returnPos]['code'] !== T_SEMICOLON && $tokens[$returnPos]['code'] !== 'PHPCS_T_NULL');
     }
 }


### PR DESCRIPTION
require docblocks for all functions (including protected and private)

> Add PHPDoc blocks for all classes, methods, and functions;
> http://symfony.com/doc/current/contributing/code/standards.html#documentation

not requiring an `@return` annotation for functions returning null

> Omit the @return tag if the method does not return anything;
> http://symfony.com/doc/current/contributing/code/standards.html#documentation

last one is open for discussion as `null` might be considered anything.
as the first one has the potential to break ci configurations, you might want to tag prior to merge
