### PR TITLE
Fix Symfony2.Arrays.MultiLineArrayComma.Invalid false positives on empty arrays and arrays with comments in them

### DIFF
--- a/Symfony2/Sniffs/Arrays/MultiLineArrayCommaSniff.php
+++ b/Symfony2/Sniffs/Arrays/MultiLineArrayCommaSniff.php
@@ -71,24 +71,40 @@ class Symfony2_Sniffs_Arrays_MultiLineArrayCommaSniff
         }
 
         if ($open['line'] <> $tokens[$closePtr]['line']) {
-            $lastComma = $phpcsFile->findPrevious(T_COMMA, $closePtr);
+            $arrayIsNotEmpty = $phpcsFile->findPrevious(
+                array(
+                    T_WHITESPACE,
+                    T_COMMENT,
+                    T_ARRAY,
+                    T_OPEN_PARENTHESIS,
+                    T_OPEN_SHORT_ARRAY,
+                ),
+                $closePtr - 1,
+                $stackPtr,
+                true
+            );
+            if ($arrayIsNotEmpty !== false) {
+                $lastCommaPtr = $phpcsFile->findPrevious(
+                    T_COMMA,
+                    $closePtr,
+                    $stackPtr
+                );
+                while ($lastCommaPtr < $closePtr -1) {
+                    $lastCommaPtr++;
 
-            while ($lastComma < $closePtr -1) {
-                $lastComma++;
-
-                if ($tokens[$lastComma]['code'] !== T_WHITESPACE
-                    && $tokens[$lastComma]['code'] !== T_COMMENT
-                ) {
-                    $phpcsFile->addError(
-                        'Add a comma after each item in a multi-line array',
-                        $stackPtr,
-                        'Invalid'
-                    );
-                    break;
+                    if ($tokens[$lastCommaPtr]['code'] !== T_WHITESPACE
+                        && $tokens[$lastCommaPtr]['code'] !== T_COMMENT
+                    ) {
+                        $phpcsFile->addError(
+                            'Add a comma after each item in a multi-line array',
+                            $stackPtr,
+                            'Invalid'
+                        );
+                        break;
+                    }
                 }
             }
         }
-
     }
 
 }

--- a/Symfony2/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Symfony2/Sniffs/Commenting/FunctionCommentSniff.php
@@ -58,7 +58,8 @@ class Symfony2_Sniffs_Commenting_FunctionCommentSniff
                 T_OPEN_TAG
             ),
             ($stackPtr - 1)
-        )) {
+        )
+        ) {
             return;
         }
 

--- a/Symfony2/Tests/Arrays/MultiLineArrayCommaUnitTest.inc
+++ b/Symfony2/Tests/Arrays/MultiLineArrayCommaUnitTest.inc
@@ -13,6 +13,9 @@ $arr = array(
         'bar'
 );
 
+$arr = array(
+);
+
 // short array syntax
 $arr = ['foo', 'bar'];
 
@@ -24,6 +27,9 @@ $arr = [
 $arr = [
         'foo'
         'bar'
+];
+
+$arr = [
 ];
 
 // classic array syntax with comments
@@ -49,6 +55,14 @@ $arr = array(
         'bar' /* baz */
 );
 
+$arr = array(
+    //'foo' => 'bar'
+);
+
+$arr = array(
+    //'foo' => 'bar',
+);
+
 // short array syntax with comments
 $arr = ['foo', 'bar' /* baz */];
 
@@ -70,4 +84,15 @@ $arr = [
 $arr = [
         'foo'
         'bar' /* baz */
+];
+
+$arr = [
+];
+
+$arr = [
+    //'foo' => 'bar'
+];
+
+$arr = [
+    //'foo' => 'bar',
 ];

--- a/Symfony2/Tests/Arrays/MultiLineArrayCommaUnitTest.php
+++ b/Symfony2/Tests/Arrays/MultiLineArrayCommaUnitTest.php
@@ -40,12 +40,12 @@ class Symfony2_Tests_Arrays_MultiLineArrayCommaUnitTest
     public function getErrorList()
     {
         return array(
-            11  => 1,
-            24 => 1,
-            37 => 1,
-            47 => 1,
-            60 => 1,
-            70 => 1,
+            11 => 1,
+            27 => 1,
+            43 => 1,
+            53 => 1,
+            74 => 1,
+            84 => 1,
         );
     }
 


### PR DESCRIPTION
Also fix PHPCS error in Sniffs/Commenting/FunctionCommentSniff.php.