### PR TITLE
Fix broken tests

### DIFF
--- a/Symfony2/Sniffs/Objects/ObjectInstantiationSniff.php
+++ b/Symfony2/Sniffs/Objects/ObjectInstantiationSniff.php
@@ -67,6 +67,7 @@ class Symfony2_Sniffs_Objects_ObjectInstantiationSniff
             T_NS_SEPARATOR,
             T_VARIABLE,
             T_STATIC,
+            T_SELF,
         );
 
         $object = $stackPtr;

--- a/Symfony2/Tests/Commenting/FunctionCommentUnitTest.inc
+++ b/Symfony2/Tests/Commenting/FunctionCommentUnitTest.inc
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @param string $test
+ * @param string $test Test argument
  */
 function test($test)
 {
@@ -9,7 +9,7 @@ function test($test)
 }
 
 /**
- * @param string $test
+ * @param string $test Test argument
  *
  * @return int
  */
@@ -19,7 +19,7 @@ function test($test)
 }
 
 /**
- * @param array $tab
+ * @param array $tab Test argument
  */
 function testWithCallBack($tab)
 {


### PR DESCRIPTION
FunctionCommentUnitTest required comments for function arguments
ObjectInstantiationSniff did not process "new self" instructions