### PR TITLE
Update repo URLs in the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "escapestudios/symfony2-coding-standard",
     "type": "coding-standard",
-    "description": "CodeSniffer ruleset for the Symfony2 coding standard",
+    "description": "CodeSniffer ruleset for the Symfony 2+ coding standard",
     "keywords": ["Symfony2", "Symfony", "coding standard", "phpcs"],
     "homepage": "https://github.com/djoos/Symfony2-coding-standard",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,8 @@
     "name": "escapestudios/symfony2-coding-standard",
     "type": "coding-standard",
     "description": "CodeSniffer ruleset for the Symfony2 coding standard",
-    "keywords": ["Symfony2", "coding standard", "phpcs"],
-    "homepage": "https://github.com/escapestudios/Symfony2-coding-standard",
+    "keywords": ["Symfony2", "Symfony", "coding standard", "phpcs"],
+    "homepage": "https://github.com/djoos/Symfony2-coding-standard",
     "license": "MIT",
     "authors": [
         {
@@ -12,7 +12,7 @@
         },
         {
             "name": "Community contributors",
-            "homepage": "https://github.com/escapestudios/Symfony2-coding-standard/graphs/contributors"
+            "homepage": "https://github.com/djoos/Symfony2-coding-standard/graphs/contributors"
         }
     ],
     "extra": {
@@ -21,10 +21,6 @@
         }
     },
     "minimum-stability": "dev",
-    "support" : {
-        "source": "https://github.com/escapestudios/Symfony2-coding-standard",
-        "issues": "https://github.com/escapestudios/Symfony2-coding-standard/issues"
-    },
     "require": {
         "squizlabs/php_codesniffer": "~2.0"
     }


### PR DESCRIPTION
I removed the support info, because Composer guesses them from the Github metadata already (the expected values are the one guessed by composer here, except that it was not allowed to guess due to the outdated URLs).

I also changed the description:
- the right way to reference Symfony is ``Symfony``, not ``Symfony2`` (the version number ``2`` must be separated from the name)
- use ``2+`` as the standard is also OK for Symfony 3.