### PR TITLE
Fix the instantiation sniff for PHPCS 2.8

### DIFF
--- a/Symfony2/Tests/Objects/ObjectInstantiationUnitTest.inc
+++ b/Symfony2/Tests/Objects/ObjectInstantiationUnitTest.inc
@@ -26,3 +26,6 @@ new $foo($this->foo);
 new static();
 new static(true);
 new static($this->foo);
+new self();
+new self(true);
+new self($this->foo);


### PR DESCRIPTION
self is now properly handled as T_SELF, so the sniff needs to allow it.