### PR TITLE
phpcs 3.*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 
 matrix:
   include:
-    - php: 5.3
     - php: 5.4
     - php: 5.5
     - php: 5.6

--- a/Symfony2/Sniffs/Arrays/MultiLineArrayCommaSniff.php
+++ b/Symfony2/Sniffs/Arrays/MultiLineArrayCommaSniff.php
@@ -12,8 +12,13 @@
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
 
+namespace Symfony2\Sniffs\Arrays;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
 /**
- * Symfony2_Sniffs_WhiteSpace_MultiLineArrayCommaSniff.
+ * MultiLineArrayCommaSniff.
  *
  * Throws warnings if the last item in a multi line array does not have a
  * trailing comma
@@ -24,8 +29,7 @@
  * @license  http://spdx.org/licenses/MIT MIT License
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
-class Symfony2_Sniffs_Arrays_MultiLineArrayCommaSniff
-    implements PHP_CodeSniffer_Sniff
+class MultiLineArrayCommaSniff implements Sniff
 {
     /**
      * A list of tokenizers this sniff supports.
@@ -53,13 +57,13 @@ class Symfony2_Sniffs_Arrays_MultiLineArrayCommaSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token
+     *                        in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         $open   = $tokens[$stackPtr];

--- a/Symfony2/Sniffs/Classes/MultipleClassesOneFileSniff.php
+++ b/Symfony2/Sniffs/Classes/MultipleClassesOneFileSniff.php
@@ -25,8 +25,13 @@
  * @license  http://spdx.org/licenses/MIT MIT License
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
-class Symfony2_Sniffs_Classes_MultipleClassesOneFileSniff
-    implements PHP_CodeSniffer_Sniff
+
+namespace Symfony2\Sniffs\Classes;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class MultipleClassesOneFileSniff implements Sniff
 {
     /**
      * The number of times the T_CLASS token is encountered in the file.
@@ -64,13 +69,13 @@ class Symfony2_Sniffs_Classes_MultipleClassesOneFileSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile All the tokens found in the document.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param File $phpcsFile All the tokens found in the document.
+     * @param int  $stackPtr  The position of the current token in
+     *                        the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if ($this->currentFile !== $phpcsFile->getFilename()) {
             $this->classCount  = 0;
@@ -82,7 +87,8 @@ class Symfony2_Sniffs_Classes_MultipleClassesOneFileSniff
         if ($this->classCount > 1) {
             $phpcsFile->addError(
                 'Multiple classes defined in a single file',
-                $stackPtr
+                $stackPtr,
+                'Invalid'
             );
         }
 

--- a/Symfony2/Sniffs/Classes/PropertyDeclarationSniff.php
+++ b/Symfony2/Sniffs/Classes/PropertyDeclarationSniff.php
@@ -12,12 +12,17 @@
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
 
+namespace Symfony2\Sniffs\Classes;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
 /**
- * Symfony2_Sniffs_Classes_PropertyDeclarationSniff.
+ * PropertyDeclarationSniff.
  *
  * Throws warnings if properties are declared after methods
  *
-* PHP version 5
+ * PHP version 5
  *
  * @category PHP
  * @package  Symfony2-coding-standard
@@ -25,8 +30,7 @@
  * @license  http://spdx.org/licenses/MIT MIT License
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
-class Symfony2_Sniffs_Classes_PropertyDeclarationSniff
-    implements PHP_CodeSniffer_Sniff
+class PropertyDeclarationSniff implements Sniff
 {
 
     /**
@@ -53,13 +57,13 @@ class Symfony2_Sniffs_Classes_PropertyDeclarationSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token
+     *                        in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Symfony2/Sniffs/Commenting/ClassCommentSniff.php
+++ b/Symfony2/Sniffs/Commenting/ClassCommentSniff.php
@@ -12,15 +12,9 @@
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
 
-if (class_exists('PHP_CodeSniffer_Tokenizers_Comment', true) === false) {
-    $error = 'Class PHP_CodeSniffer_Tokenizers_Comment not found';
-    throw new PHP_CodeSniffer_Exception($error);
-}
+namespace Symfony2\Sniffs\Commenting;
 
-if (class_exists('PEAR_Sniffs_Commenting_ClassCommentSniff', true) === false) {
-    $error = 'Class PEAR_Sniffs_Commenting_ClassCommentSniff not found';
-    throw new PHP_CodeSniffer_Exception($error);
-}
+use PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\ClassCommentSniff as PearClassCommentSniff;
 
 /**
  * Parses and verifies the doc comments for classes.
@@ -44,8 +38,7 @@ if (class_exists('PEAR_Sniffs_Commenting_ClassCommentSniff', true) === false) {
  * @license  http://spdx.org/licenses/MIT MIT License
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Symfony2_Sniffs_Commenting_ClassCommentSniff
-    extends PEAR_Sniffs_Commenting_ClassCommentSniff
+class ClassCommentSniff extends PearClassCommentSniff
 {
     /**
      * Tags in correct order and related info.

--- a/Symfony2/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Symfony2/Sniffs/Commenting/FunctionCommentSniff.php
@@ -12,10 +12,10 @@
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
 
-if (class_exists('PEAR_Sniffs_Commenting_FunctionCommentSniff', true) === false) {
-    $error = 'Class PEAR_Sniffs_Commenting_FunctionCommentSniff not found';
-    throw new PHP_CodeSniffer_Exception($error);
-}
+namespace Symfony2\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FunctionCommentSniff as PearFunctionCommentSniff;
 
 /**
  * Symfony2 standard customization to PEARs FunctionCommentSniff.
@@ -35,19 +35,18 @@ if (class_exists('PEAR_Sniffs_Commenting_FunctionCommentSniff', true) === false)
  * @license  http://spdx.org/licenses/MIT MIT License
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Symfony2_Sniffs_Commenting_FunctionCommentSniff
-    extends PEAR_Sniffs_Commenting_FunctionCommentSniff
+class FunctionCommentSniff extends PearFunctionCommentSniff
 {
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token
+     *                        in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         if (false === $commentEnd = $phpcsFile->findPrevious(
             array(
@@ -82,16 +81,16 @@ class Symfony2_Sniffs_Commenting_FunctionCommentSniff
     /**
      * Process the return comment of this function comment.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
-     * @param int                  $stackPtr     The position of the current token
-     *                                           in the stack passed in $tokens.
-     * @param int                  $commentStart The position in the stack
-     *                                           where the comment started.
+     * @param File $phpcsFile    The file being scanned.
+     * @param int  $stackPtr     The position of the current token
+     *                           in the stack passed in $tokens.
+     * @param int  $commentStart The position in the stack
+     *                           where the comment started.
      *
      * @return void
      */
     protected function processReturn(
-        PHP_CodeSniffer_File $phpcsFile,
+        File $phpcsFile,
         $stackPtr,
         $commentStart
     ) {
@@ -133,13 +132,13 @@ class Symfony2_Sniffs_Commenting_FunctionCommentSniff
     /**
      * Is the comment an inheritdoc?
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token
+     *                        in the stack passed in $tokens.
      *
      * @return boolean True if the comment is an inheritdoc
      */
-    protected function isInheritDoc(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    protected function isInheritDoc(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -154,16 +153,16 @@ class Symfony2_Sniffs_Commenting_FunctionCommentSniff
     /**
      * Process the function parameter comments.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile    The file being scanned.
-     * @param int                  $stackPtr     The position of the current token
-     *                                           in the stack passed in $tokens.
-     * @param int                  $commentStart The position in the stack
-     *                                           where the comment started.
+     * @param File $phpcsFile    The file being scanned.
+     * @param int  $stackPtr     The position of the current token
+     *                           in the stack passed in $tokens.
+     * @param int  $commentStart The position in the stack
+     *                           where the comment started.
      *
      * @return void
      */
     protected function processParams(
-        PHP_CodeSniffer_File $phpcsFile,
+        File $phpcsFile,
         $stackPtr,
         $commentStart
     ) {

--- a/Symfony2/Sniffs/Formatting/BlankLineBeforeReturnSniff.php
+++ b/Symfony2/Sniffs/Formatting/BlankLineBeforeReturnSniff.php
@@ -25,8 +25,12 @@
  * @license  http://spdx.org/licenses/MIT MIT License
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
-class Symfony2_Sniffs_Formatting_BlankLineBeforeReturnSniff
-    implements PHP_CodeSniffer_Sniff
+namespace Symfony2\Sniffs\Formatting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+class BlankLineBeforeReturnSniff implements Sniff
 {
     /**
      * A list of tokenizers this sniff supports.
@@ -51,13 +55,13 @@ class Symfony2_Sniffs_Formatting_BlankLineBeforeReturnSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile All the tokens found in the document.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param File $phpcsFile All the tokens found in the document.
+     * @param int  $stackPtr  The position of the current token in
+     *                        the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens          = $phpcsFile->getTokens();
         $current         = $stackPtr;
@@ -84,7 +88,8 @@ class Symfony2_Sniffs_Formatting_BlankLineBeforeReturnSniff
         } else if (count($prevLineTokens) > 0) {
             $phpcsFile->addError(
                 'Missing blank line before return statement',
-                $stackPtr
+                $stackPtr,
+                'Invalid'
             );
         }
 

--- a/Symfony2/Sniffs/Functions/ScopeOrderSniff.php
+++ b/Symfony2/Sniffs/Functions/ScopeOrderSniff.php
@@ -12,8 +12,13 @@
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
 
+namespace Symfony2\Sniffs\Functions;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
 /**
- * Symfony2_Sniffs_Functions_ScopeOrderSniff.
+ * ScopeOrderSniff.
  *
  * Throws warnings if properties are declared after methods
  *
@@ -25,8 +30,7 @@
  * @license  http://spdx.org/licenses/MIT MIT License
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
-class Symfony2_Sniffs_Functions_ScopeOrderSniff
-    implements PHP_CodeSniffer_Sniff
+class ScopeOrderSniff implements Sniff
 {
 
     /**
@@ -54,13 +58,13 @@ class Symfony2_Sniffs_Functions_ScopeOrderSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token
+     *                        in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         $function = $stackPtr;

--- a/Symfony2/Sniffs/NamingConventions/ValidClassNameSniff.php
+++ b/Symfony2/Sniffs/NamingConventions/ValidClassNameSniff.php
@@ -12,8 +12,13 @@
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
 
+namespace Symfony2\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
 /**
- * Symfony2_Sniffs_NamingConventions_ValidClassNameSniff.
+ * ValidClassNameSniff.
  *
  * Throws errors if symfony's naming conventions are not met.
  *
@@ -25,8 +30,7 @@
  * @license  http://spdx.org/licenses/MIT MIT License
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
-class Symfony2_Sniffs_NamingConventions_ValidClassNameSniff
-    implements PHP_CodeSniffer_Sniff
+class ValidClassNameSniff implements Sniff
 {
     /**
      * A list of tokenizers this sniff supports.
@@ -55,13 +59,13 @@ class Symfony2_Sniffs_NamingConventions_ValidClassNameSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile All the tokens found in the document.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param File $phpcsFile All the tokens found in the document.
+     * @param int  $stackPtr  The position of the current token in
+     *                        the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens   = $phpcsFile->getTokens();
         $line     = $tokens[$stackPtr]['line'];

--- a/Symfony2/Sniffs/Objects/ObjectInstantiationSniff.php
+++ b/Symfony2/Sniffs/Objects/ObjectInstantiationSniff.php
@@ -12,8 +12,13 @@
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
 
+namespace Symfony2\Sniffs\Objects;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
 /**
- * Symfony2_Sniffs_Objects_ObjectInstantiationSniff.
+ * ObjectInstantiationSniff.
  *
  * Throws a warning if an object isn't instantiated using parenthesis.
  *
@@ -25,8 +30,7 @@
  * @license  http://spdx.org/licenses/MIT MIT License
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
-class Symfony2_Sniffs_Objects_ObjectInstantiationSniff
-    implements PHP_CodeSniffer_Sniff
+class ObjectInstantiationSniff implements Sniff
 {
     /**
      * A list of tokenizers this sniff supports.
@@ -53,13 +57,13 @@ class Symfony2_Sniffs_Objects_ObjectInstantiationSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token
+     *                        in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         $allowed = array(

--- a/Symfony2/Sniffs/Scope/MethodScopeSniff.php
+++ b/Symfony2/Sniffs/Scope/MethodScopeSniff.php
@@ -12,11 +12,11 @@
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
 
-if (class_exists('PHP_CodeSniffer_Standards_AbstractScopeSniff', true) === false) {
-    throw new PHP_CodeSniffer_Exception(
-        'Class PHP_CodeSniffer_Standards_AbstractScopeSniff not found'
-    );
-}
+namespace Symfony2\Sniffs\Objects;
+
+use PHP_CodeSniffer\Sniffs\AbstractScopeSniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
 
 /**
  * Verifies that class members have scope modifiers.
@@ -29,11 +29,10 @@ if (class_exists('PHP_CodeSniffer_Standards_AbstractScopeSniff', true) === false
  * @license  http://spdx.org/licenses/MIT MIT License
  * @link     http://pear.php.net/package/PHP_CodeSniffer
  */
-class Symfony2_Sniffs_Scope_MethodScopeSniff
-    extends PHP_CodeSniffer_Standards_AbstractScopeSniff
+class MethodScopeSniff extends AbstractScopeSniff
 {
     /**
-     * Constructs a Symfony2_Sniffs_Scope_MethodScopeSniff.
+     * Constructs a MethodScopeSniff.
      */
     public function __construct()
     {
@@ -44,14 +43,14 @@ class Symfony2_Sniffs_Scope_MethodScopeSniff
     /**
      * Processes the function tokens within the class.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file where this token was found.
-     * @param int                  $stackPtr  The position where the token was found.
-     * @param int                  $currScope The current scope opener token.
+     * @param File $phpcsFile The file where this token was found.
+     * @param int  $stackPtr  The position where the token was found.
+     * @param int  $currScope The current scope opener token.
      *
      * @return void
      */
     protected function processTokenWithinScope(
-        PHP_CodeSniffer_File $phpcsFile,
+        File $phpcsFile,
         $stackPtr,
         $currScope
     ) {
@@ -64,7 +63,7 @@ class Symfony2_Sniffs_Scope_MethodScopeSniff
         }
 
         $modifier = $phpcsFile->findPrevious(
-            PHP_CodeSniffer_Tokens::$scopeModifiers,
+            Tokens::$scopeModifiers,
             $stackPtr
         );
 
@@ -76,5 +75,15 @@ class Symfony2_Sniffs_Scope_MethodScopeSniff
             $phpcsFile->addError($error, $stackPtr, 'Missing', $data);
         }
 
+    }
+
+    /**
+     * Process tokens outside scope.
+     *
+     * @param File $phpcsFile
+     * @param int  $stackPtr
+     */
+    protected function processTokenOutsideScope(File $phpcsFile, $stackPtr)
+    {
     }
 }

--- a/Symfony2/Sniffs/WhiteSpace/AssignmentSpacingSniff.php
+++ b/Symfony2/Sniffs/WhiteSpace/AssignmentSpacingSniff.php
@@ -12,8 +12,14 @@
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
 
+namespace Symfony2\Sniffs\Whitespace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
 /**
- * Symfony2_Sniffs_WhiteSpace_AssignmentSpacingSniff.
+ * AssignmentSpacingSniff.
  *
  * Throws warnings if an assignment operator isn't surrounded with whitespace.
  *
@@ -25,8 +31,7 @@
  * @license  http://spdx.org/licenses/MIT MIT License
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
-class Symfony2_Sniffs_WhiteSpace_AssignmentSpacingSniff
-    implements PHP_CodeSniffer_Sniff
+class AssignmentSpacingSniff implements Sniff
 {
     /**
      * A list of tokenizers this sniff supports.
@@ -44,20 +49,20 @@ class Symfony2_Sniffs_WhiteSpace_AssignmentSpacingSniff
      */
     public function register()
     {
-        return PHP_CodeSniffer_Tokens::$assignmentTokens;
+        return Tokens::$assignmentTokens;
 
     }
 
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token
+     *                        in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Symfony2/Sniffs/WhiteSpace/BinaryOperatorSpacingSniff.php
+++ b/Symfony2/Sniffs/WhiteSpace/BinaryOperatorSpacingSniff.php
@@ -12,8 +12,14 @@
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
 
+namespace Symfony2\Sniffs\Whitespace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Util\Tokens;
+
 /**
- * Symfony2_Sniffs_WhiteSpace_BinaryOperatorSpacingSniff.
+ * SBinaryOperatorSpacingSniff.
  *
  * Throws warnings if a binary operator isn't surrounded with whitespace.
  *
@@ -25,8 +31,7 @@
  * @license  http://spdx.org/licenses/MIT MIT License
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
-class Symfony2_Sniffs_WhiteSpace_BinaryOperatorSpacingSniff
-    implements PHP_CodeSniffer_Sniff
+class SBinaryOperatorSpacingSniff implements Sniff
 {
     /**
      * A list of tokenizers this sniff supports.
@@ -44,20 +49,20 @@ class Symfony2_Sniffs_WhiteSpace_BinaryOperatorSpacingSniff
      */
     public function register()
     {
-        return PHP_CodeSniffer_Tokens::$comparisonTokens;
+        return Tokens::$comparisonTokens;
 
     }
 
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token
+     *                        in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 

--- a/Symfony2/Sniffs/WhiteSpace/CommaSpacingSniff.php
+++ b/Symfony2/Sniffs/WhiteSpace/CommaSpacingSniff.php
@@ -12,8 +12,13 @@
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
 
+namespace Symfony2\Sniffs\Whitespace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
 /**
- * Symfony2_Sniffs_WhiteSpace_CommaSpacingSniff.
+ * CommaSpacingSniff.
  *
  * Throws warnings if comma isn't followed by a whitespace.
  *
@@ -25,8 +30,7 @@
  * @license  http://spdx.org/licenses/MIT MIT License
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
-class Symfony2_Sniffs_WhiteSpace_CommaSpacingSniff
-    implements PHP_CodeSniffer_Sniff
+class CommaSpacingSniff implements Sniff
 {
     /**
      * A list of tokenizers this sniff supports.
@@ -53,13 +57,13 @@ class Symfony2_Sniffs_WhiteSpace_CommaSpacingSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
-     * @param int                  $stackPtr  The position of the current token
-     *                                        in the stack passed in $tokens.
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  The position of the current token
+     *                        in the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
         $line   = $tokens[$stackPtr]['line'];

--- a/Symfony2/Sniffs/WhiteSpace/DiscourageFitzinatorSniff.php
+++ b/Symfony2/Sniffs/WhiteSpace/DiscourageFitzinatorSniff.php
@@ -12,8 +12,13 @@
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
 
+namespace Symfony2\Sniffs\Whitespace;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
 /**
- * Symfony2_Sniffs_WhiteSpace_DiscourageFitzinatorSniff.
+ * DiscourageFitzinatorSniff.
  *
  * Throws warnings if a file contains trailing whitespace.
  *
@@ -25,8 +30,7 @@
  * @license  http://spdx.org/licenses/MIT MIT License
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
-class Symfony2_Sniffs_WhiteSpace_DiscourageFitzinatorSniff
-    implements PHP_CodeSniffer_Sniff
+class DiscourageFitzinatorSniff implements Sniff
 {
     /**
      * A list of tokenizers this sniff supports.
@@ -54,13 +58,13 @@ class Symfony2_Sniffs_WhiteSpace_DiscourageFitzinatorSniff
     /**
      * Processes this test, when one of its tokens is encountered.
      *
-     * @param PHP_CodeSniffer_File $phpcsFile All the tokens found in the document.
-     * @param int                  $stackPtr  The position of the current token in
-     *                                        the stack passed in $tokens.
+     * @param File $phpcsFile All the tokens found in the document.
+     * @param int  $stackPtr  The position of the current token in
+     *                        the stack passed in $tokens.
      *
      * @return void
      */
-    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         $tokens = $phpcsFile->getTokens();
 
@@ -76,7 +80,7 @@ class Symfony2_Sniffs_WhiteSpace_DiscourageFitzinatorSniff
             || strpos($tokens[$stackPtr]['content'], "\r") > 0
         ) {
             $warning = 'Please trim any trailing whitespace';
-            $phpcsFile->addWarning($warning, $stackPtr);
+            $phpcsFile->addWarning($warning, $stackPtr, 'Invalid');
         }
     }
 }

--- a/Symfony2/Tests/Arrays/MultiLineArrayCommaUnitTest.php
+++ b/Symfony2/Tests/Arrays/MultiLineArrayCommaUnitTest.php
@@ -12,6 +12,10 @@
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
 
+namespace Symfony2\Tests\Arrays;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the MultiLineArrayComma sniff.
  *
@@ -26,8 +30,7 @@
  * @license  http://spdx.org/licenses/MIT MIT License
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
-class Symfony2_Tests_Arrays_MultiLineArrayCommaUnitTest
-    extends AbstractSniffUnitTest
+class MultiLineArrayCommaUnitTest extends AbstractSniffUnitTest
 {
     /**
      * Returns the lines where errors should occur.

--- a/Symfony2/Tests/Commenting/FunctionCommentUnitTest.php
+++ b/Symfony2/Tests/Commenting/FunctionCommentUnitTest.php
@@ -12,6 +12,10 @@
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
 
+namespace Symfony2\Tests\Commenting;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the FunctionComment sniff.
  *
@@ -26,8 +30,7 @@
  * @license  http://spdx.org/licenses/MIT MIT License
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
-class Symfony2_Tests_Commenting_FunctionCommentUnitTest
-    extends AbstractSniffUnitTest
+class FunctionCommentUnitTest extends AbstractSniffUnitTest
 {
     /**
      * Returns the lines where errors should occur.

--- a/Symfony2/Tests/Formatting/BlankLineBeforeReturnUnitTest.php
+++ b/Symfony2/Tests/Formatting/BlankLineBeforeReturnUnitTest.php
@@ -12,6 +12,10 @@
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
 
+namespace Symfony2\Tests\Formatting;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the BlankLineBeforeReturn sniff.
  *
@@ -26,8 +30,7 @@
  * @license  http://spdx.org/licenses/MIT MIT License
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
-class Symfony2_Tests_Formatting_BlankLineBeforeReturnUnitTest
-    extends AbstractSniffUnitTest
+class BlankLineBeforeReturnUnitTest extends AbstractSniffUnitTest
 {
     /**
      * Returns the lines where errors should occur.

--- a/Symfony2/Tests/Objects/ObjectInstantiationUnitTest.php
+++ b/Symfony2/Tests/Objects/ObjectInstantiationUnitTest.php
@@ -12,6 +12,10 @@
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
 
+namespace Symfony2\Tests\Objects;
+
+use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest;
+
 /**
  * Unit test class for the ObjectInstantiation sniff.
  *
@@ -26,8 +30,7 @@
  * @license  http://spdx.org/licenses/MIT MIT License
  * @link     https://github.com/escapestudios/Symfony2-coding-standard
  */
-class Symfony2_Tests_Objects_ObjectInstantiationUnitTest
-    extends AbstractSniffUnitTest
+class ObjectInstantiationUnitTest extends AbstractSniffUnitTest
 {
     /**
      * Returns the lines where errors should occur.

--- a/build.properties
+++ b/build.properties
@@ -5,4 +5,4 @@ composer.path = ${basedir}/composer.phar
 #PHP Code Sniffer
 phpcs.standard = PEAR
 phpcs.dir = ${basedir}/vendor/squizlabs/php_codesniffer
-phpcs.symlink.path = vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/Symfony2
+phpcs.symlink.path = vendor/squizlabs/php_codesniffer/src/Standards/Symfony2

--- a/build.xml
+++ b/build.xml
@@ -41,7 +41,6 @@
 
     <target name="phpunit" depends="symlink-this-coding-standard" description="Run unit tests with PHPUnit">
         <exec executable="phpunit" failonerror="true" >
-            <arg value="--filter=Symfony2_*" />
             <arg value="${phpcs.dir}/tests/AllTests.php" />
         </exec>
     </target>

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     ],
     "extra": {
         "branch-alias": {
-            "dev-master": "2.x-dev"
+            "dev-master": "3.x-dev"
         }
     },
     "minimum-stability": "dev",
     "require": {
-        "squizlabs/php_codesniffer": "~2.0"
+        "squizlabs/php_codesniffer": "3.*"
     }
 }


### PR DESCRIPTION
updated all sniffs from tag 2.10.1 so they are compatible with phpcs version 3
fixes #61 

###### note:
due to the changed class names you won't be able to use the ``--filter`` construction like you used to do in your build.xml. and i've changed the ``branch-alias`` in the ``composer.json`` file assuming you're going to tag this once it's merged