### PR TITLE
fixes a bug where PEAR errors of type Missing wouldn't show up as errors

### DIFF
--- a/Symfony/ruleset.xml
+++ b/Symfony/ruleset.xml
@@ -88,6 +88,14 @@
         <severity>0</severity>
     </rule>
 
+    <rule ref="Symfony.Commenting.FunctionComment.Missing">
+        <type>error</type>
+    </rule>
+
+    <rule ref="Symfony.Commenting.ClassComment.Missing">
+        <type>error</type>
+    </rule>
+
     <rule ref="Symfony.Commenting.FunctionComment.SpacingBeforeTags">
         <severity>0</severity>
     </rule>


### PR DESCRIPTION
leftover of migrating from phpcs 2 to 3.

unsure why all of a sudden this sniff stopped working for error type ``Missing`` (and unit tests didn't complain one bit about it), but this mod ensures missing function and class comments do show up again in the report.