### PR TITLE
require function comments for every type of visibility

### DIFF
--- a/Symfony/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Symfony/Sniffs/Commenting/FunctionCommentSniff.php
@@ -38,47 +38,6 @@ use PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FunctionCommentSniff as Pea
 class FunctionCommentSniff extends PearFunctionCommentSniff
 {
     /**
-     * Processes this test, when one of its tokens is encountered.
-     *
-     * @param File $phpcsFile The file being scanned.
-     * @param int  $stackPtr  The position of the current token
-     *                        in the stack passed in $tokens.
-     *
-     * @return void
-     */
-    public function process(File $phpcsFile, $stackPtr)
-    {
-        if (false === $commentEnd = $phpcsFile->findPrevious(
-            array(
-                T_COMMENT,
-                T_DOC_COMMENT,
-                T_CLASS,
-                T_FUNCTION,
-                T_OPEN_TAG
-            ),
-            ($stackPtr - 1)
-        )
-        ) {
-            return;
-        }
-
-        $tokens = $phpcsFile->getTokens();
-        $code = $tokens[$commentEnd]['code'];
-
-        // a comment is not required on protected/private methods
-        $method = $phpcsFile->getMethodProperties($stackPtr);
-        $commentRequired = 'public' == $method['scope'];
-
-        if (($code === T_COMMENT && !$commentRequired)
-            || ($code !== T_DOC_COMMENT && !$commentRequired)
-        ) {
-            return;
-        }
-
-        parent::process($phpcsFile, $stackPtr);
-    }
-
-    /**
      * Process the return comment of this function comment.
      *
      * @param File $phpcsFile    The file being scanned.


### PR DESCRIPTION
as recorded in #69 

will raise an (additional) error if a protected or private function has no function comment