### PR TITLE
Declare all the arguments on the same line as the method/function name

### DIFF
--- a/Symfony/Sniffs/Functions/ArgumentsSniff.php
+++ b/Symfony/Sniffs/Functions/ArgumentsSniff.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of the Symfony2-coding-standard (phpcs standard)
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  Symfony2-coding-standard
+ * @author   Authors <Symfony2-coding-standard@djoos.github.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     https://github.com/djoos/Symfony2-coding-standard
+ */
+
+namespace Symfony\Sniffs\Functions;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Checks whether functions are defined on one line.
+ *
+ * @category PHP
+ * @package  Symfony2-coding-standard
+ * @author   wicliff wolda <wicliff.wolda@gmail.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ArgumentsSniff implements Sniff
+{
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     */
+    public function register()
+    {
+        return array(
+            T_FUNCTION,
+        );
+    }
+
+    /**
+     * Called when one of the token types that this sniff is listening for
+     * is found.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     * @param int                         $stackPtr  The position in the PHP_CodeSniffer
+     *                                               file's token stack where the token
+     *                                               was found.
+     *
+     * @return void|int Optionally returns a stack pointer. The sniff will not be
+     *                  called again on the current file until the returned stack
+     *                  pointer is reached. Return (count($tokens) + 1) to skip
+     *                  the rest of the file.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $function = $tokens[$stackPtr];
+
+        if ($tokens[$function['parenthesis_opener']]['line'] !== $tokens[$function['parenthesis_closer']]['line']) {
+            $error = 'Declare all the arguments on the same line as the method/function name, no matter how many arguments there are.';
+            $phpcsFile->addError($error, $stackPtr, 'Invalid');
+        }
+    }
+
+}


### PR DESCRIPTION
raises an error for multiline function declaration

as recorded in #66

###### note: 
i didn't include a unit test as they appear to be doing absolutely nothing during the build. will try to fix this in a seperate pr