### PR TITLE
concat exception message with sprintf

### DIFF
--- a/Symfony/Sniffs/Errors/ExceptionMessageSniff.php
+++ b/Symfony/Sniffs/Errors/ExceptionMessageSniff.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * This file is part of the Symfony2-coding-standard (phpcs standard)
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  Symfony2-coding-standard
+ * @author   Authors <Symfony2-coding-standard@djoos.github.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     https://github.com/djoos/Symfony2-coding-standard
+ */
+
+namespace Symfony\Sniffs\Errors;
+
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Checks whether functions are defined on one line.
+ *
+ * @category PHP
+ * @package  Symfony2-coding-standard
+ * @author   wicliff wolda <wicliff.wolda@gmail.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class ExceptionMessageSniff implements Sniff
+{
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     */
+    public function register()
+    {
+        return array(
+            T_THROW,
+        );
+    }
+
+    /**
+     * Called when one of the token types that this sniff is listening for
+     * is found.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     * @param int                         $stackPtr  The position in the PHP_CodeSniffer
+     *                                               file's token stack where the token
+     *                                               was found.
+     *
+     * @return void|int Optionally returns a stack pointer. The sniff will not be
+     *                  called again on the current file until the returned stack
+     *                  pointer is reached. Return (count($tokens) + 1) to skip
+     *                  the rest of the file.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+        $opener = $phpcsFile->findNext(T_OPEN_PARENTHESIS, $stackPtr);
+
+        if ($phpcsFile->findNext(T_STRING_CONCAT, $tokens[$opener]['parenthesis_opener'], $tokens[$opener]['parenthesis_closer'])) {
+            $error = 'Exception and error message strings must be concatenated using sprintf';
+            $phpcsFile->addError($error, $stackPtr, 'Invalid');
+        }
+    }
+
+}

--- a/Symfony/ruleset.xml
+++ b/Symfony/ruleset.xml
@@ -14,19 +14,6 @@
     <!--
 
     See the [documented coding standard](http://symfony.com/doc/current/contributing/code/standards.html)
-
-    This CodeSniffer standard does not yet enforce the following:
-
-    # Structure
-
-    * The @package and @subpackage annotations are not used.
-    * Use uppercase strings for constants with words separated with underscores
-    * Exception message strings should be concatenated using sprintf
-
-    # Naming Conventions
-
-    * Use underscores for option, argument, parameter names;
-
     -->
 
     <rule ref="Generic.ControlStructures.InlineControlStructure"/>


### PR DESCRIPTION
adds an error if ``T_STRING_CONCAT`` is used within an exception message

recorded in #66 