### PR TITLE
structure: equality

### DIFF
--- a/Symfony/Sniffs/ControlStructure/IdenticalComparisonSniff.php
+++ b/Symfony/Sniffs/ControlStructure/IdenticalComparisonSniff.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the Symfony2-coding-standard (phpcs standard)
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  Symfony2-coding-standard
+ * @author   Authors <Symfony2-coding-standard@djoos.github.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     https://github.com/djoos/Symfony2-coding-standard
+ */
+
+namespace Symfony\Sniffs\ControlStructure;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Checks for identical comparison and adds warning if not used.
+ *
+ * @category PHP
+ * @package  Symfony2-coding-standard
+ * @author   wicliff wolda <wicliff.wolda@gmail.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class IdenticalComparisonSniff implements Sniff
+{
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     */
+    public function register()
+    {
+        return array(
+            T_IS_EQUAL,
+            T_IS_NOT_EQUAL,
+        );
+    }
+
+    /**
+     * Called when one of the token types that this sniff is listening for
+     * is found.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     * @param int                         $stackPtr  The position in the PHP_CodeSniffer
+     *                                               file's token stack where the token
+     *                                               was found.
+     *
+     * @return void|int Optionally returns a stack pointer. The sniff will not be
+     *                  called again on the current file until the returned stack
+     *                  pointer is reached. Return (count($tokens) + 1) to skip
+     *                  the rest of the file.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $phpcsFile->addWarning('Always use identical comparison unless you need type juggling', $stackPtr, 'Warning');
+    }
+
+}


### PR DESCRIPTION
Checks for identical comparison and adds warning (as there's no way to know whether type juggling is needed) if not used.

recorded in #66