### PR TITLE
documentation: license

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This standard can be installed with the [Composer](https://getcomposer.org/) dep
 
 2. Install the coding standard as a dependency of your project
 
-        composer require --dev escapestudios/symfony2-coding-standard:^3.*
+        composer require --dev escapestudios/symfony2-coding-standard:3.x-dev
 
 3. Add the coding standard to the PHP_CodeSniffer install path
 

--- a/Symfony/Sniffs/Commenting/LicenseSniff.php
+++ b/Symfony/Sniffs/Commenting/LicenseSniff.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of the Symfony2-coding-standard (phpcs standard)
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  Symfony2-coding-standard
+ * @author   Authors <Symfony2-coding-standard@djoos.github.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     https://github.com/djoos/Symfony2-coding-standard
+ */
+
+namespace Symfony\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Checks for the presence of a license comment prior to the namespace.
+ *
+ * @category PHP
+ * @package  Symfony2-coding-standard
+ * @author   wicliff wolda <wicliff.wolda@gmail.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
+class LicenseSniff implements Sniff
+{
+
+    /**
+     * Registers the tokens that this sniff wants to listen for.
+     */
+    public function register()
+    {
+        return [
+            T_NAMESPACE
+        ];
+    }
+
+    /**
+     * Called when one of the token types that this sniff is listening for
+     * is found.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     * @param int                         $stackPtr  The position in the PHP_CodeSniffer
+     *                                               file's token stack where the token
+     *                                               was found.
+     *
+     * @return void|int Optionally returns a stack pointer. The sniff will not be
+     *                  called again on the current file until the returned stack
+     *                  pointer is reached. Return (count($tokens) + 1) to skip
+     *                  the rest of the file.
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        if (false === $phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, $stackPtr)) {
+            $phpcsFile->addWarning(
+                'The license block has to be present at the top of every PHP file, before the namespace',
+                $stackPtr,
+                'Warning'
+            );
+        }
+    }
+}

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -4,6 +4,7 @@ UPGRADE FROM 2.x TO 3.0
 Table of contents
 - [Standard](#standard)
 - [Ruleset](#ruleset)
+- [Warnings](#warnings)
 
 Standard
 --------
@@ -31,3 +32,11 @@ After:
     // ...
 </rule>
 ```
+
+Warnings
+--------
+Both the ``The license block has to be present at the top of every PHP file, before the namespace`` and the ``Always use identical comparison unless you need type juggling`` messages will appear as warnings as these sniffs are unable to determine whether or not it's an error.
+In order to suppress those warnings one can get rid of them with: 
+ ```
+ phpcs --config-set show_warnings 0
+ ```


### PR DESCRIPTION
The license block has to be present at the top of every PHP file, before the namespace

recorded in #69

a sniff a day keeps the doctor away... 😎 

as mentioned in #69, this one just raises a warning as it appears to be specific to contributing to any symfony repository so shouldn't raise an error as far as i'm concerned. also no check whether the comment actual contains a ``license`` reference as placing any other comment prior to the namespace doesn't really make sense to me.

👍 for all the quick merges today @djoos, very much appreciated