### PR TITLE
documentation: return tag

### DIFF
--- a/Symfony/ruleset.xml
+++ b/Symfony/ruleset.xml
@@ -87,6 +87,10 @@
         <type>error</type>
     </rule>
 
+    <rule ref="Symfony.Commenting.FunctionComment.MissingReturn">
+        <type>error</type>
+    </rule>
+
     <rule ref="Symfony.Commenting.FunctionComment.SpacingBeforeTags">
         <severity>0</severity>
     </rule>


### PR DESCRIPTION
Omit the @return tag if the method does not return anything

recorded in #69 

this one just needed a severity modification in order for it to work...