### PR TITLE
fixes a bug in the license sniff

### DIFF
--- a/Symfony/Sniffs/Commenting/LicenseSniff.php
+++ b/Symfony/Sniffs/Commenting/LicenseSniff.php
@@ -56,7 +56,7 @@ class LicenseSniff implements Sniff
      */
     public function process(File $phpcsFile, $stackPtr)
     {
-        if (false === $phpcsFile->findPrevious(T_DOC_COMMENT_OPEN_TAG, $stackPtr)) {
+        if (false === $phpcsFile->findPrevious([T_COMMENT, T_DOC_COMMENT_OPEN_TAG], $stackPtr)) {
             $phpcsFile->addWarning(
                 'The license block has to be present at the top of every PHP file, before the namespace',
                 $stackPtr,


### PR DESCRIPTION
where the license has been defined as a comment rather than a doc comment.

oops, this one slipped through