### PR TITLE
annotation bug

### DIFF
--- a/Symfony/Sniffs/Commenting/AnnotationsSniff.php
+++ b/Symfony/Sniffs/Commenting/AnnotationsSniff.php
@@ -1,19 +1,38 @@
 <?php
 
+/**
+ * This file is part of the Symfony2-coding-standard (phpcs standard)
+ *
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  Symfony2-coding-standard
+ * @author   Authors <Symfony2-coding-standard@djoos.github.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     https://github.com/djoos/Symfony2-coding-standard
+ */
 
 namespace Symfony\Sniffs\Commenting;
-
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 
+/**
+ * Checks whether annotations of a different type are seperated with newlines.
+ *
+ * @category PHP
+ * @package  Symfony2-coding-standard
+ * @author   wicliff wolda <wicliff.wolda@gmail.com>
+ * @license  http://spdx.org/licenses/MIT MIT License
+ * @link     http://pear.php.net/package/PHP_CodeSniffer
+ */
 class AnnotationsSniff implements Sniff
 {
 
-    private static $pattern = '/^@([^\/]+)[\/]?*$/i';
+    private static $pattern = '/^@([^\\\(]+).*$/i';
 
     /**
-     * @inheritDoc
+     * Registers the tokens that this sniff wants to listen for.
      */
     public function register()
     {
@@ -23,7 +42,19 @@ class AnnotationsSniff implements Sniff
     }
 
     /**
-     * @inheritDoc
+     * Called when one of the token types that this sniff is listening for
+     * is found.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The PHP_CodeSniffer file where the
+     *                                               token was found.
+     * @param int                         $stackPtr  The position in the PHP_CodeSniffer
+     *                                               file's token stack where the token
+     *                                               was found.
+     *
+     * @return void|int Optionally returns a stack pointer. The sniff will not be
+     *                  called again on the current file until the returned stack
+     *                  pointer is reached. Return (count($tokens) + 1) to skip
+     *                  the rest of the file.
      */
     public function process(File $phpcsFile, $stackPtr)
     {
@@ -31,10 +62,10 @@ class AnnotationsSniff implements Sniff
         $closer = $phpcsFile->findNext(T_DOC_COMMENT_CLOSE_TAG, $stackPtr);
 
         if (false !== $next = $phpcsFile->findNext($this->register(), $stackPtr + 1, $closer)) {
-            $first = explode('\\', $tokens[$stackPtr]['content'])[0];
-            $second = explode('\\', $tokens[$next]['content'])[0];
+            $first = preg_replace(self::$pattern, '$1', $tokens[$stackPtr]['content']);
+            $second = preg_replace(self::$pattern, '$1', $tokens[$next]['content']);
 
-            if ($first !== $second && $tokens[$stackPtr]['line'] + 2 !== $tokens[$next]['line']) {
+            if ($first !== $second && $tokens[$stackPtr]['line'] + 2 > $tokens[$next]['line']) {
                 $phpcsFile->addError(
                     'Group annotations together so that annotations of the same type immediately follow each other, and annotations of a different type are separated by a single blank line',
                     $stackPtr,


### PR DESCRIPTION
fixes a bug where a single annotation spans multiple lines.

```php
    /**
     * @ORM\JoinTable(
     *     joinColumns={@ORM\JoinColumn(name="// ...,
     *     inverseJoinColumns={@ORM\JoinColumn(name="// ...
     * )
     *
     * @SER\Groups("// ...
```
or with annotations which are not aliased
```php
    /**
     * @UniqueEntity(fields="email", message="user.email.duplicate")
     * @UniqueEntity(fields="username", message="user.username.duplicate")
     * // ...
```

should no longer trigger an error